### PR TITLE
http -> https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # string-search
 Parking lot for advice on internationalization related string searching in general content.
 
-Read the document at http://w3c.github.io/string-search/
+Read the document at https://w3c.github.io/string-search/

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           noRecTrack:           true,
           shortName:            "string-search",
           copyrightStart: 		"2016",
-          edDraftURI:   		"http://w3c.github.io/string-search/",
+          edDraftURI:   		"https://w3c.github.io/string-search/",
 
           // lcEnd: "2009-08-05",
 
@@ -38,7 +38,7 @@
           
           // name of the WG
           wg:           "Internationalization Working Group",
-          wgURI:        "http://www.w3.org/International/core/",
+          wgURI:        "https://www.w3.org/International/core/",
           wgPublicList: "www-international",
           
 		  bugTracker: { new: "https://github.com/w3c/string-search/issues", open: "https://github.com/w3c/string-search/issues" } ,
@@ -59,19 +59,19 @@
           // This is important for Rec-track documents, do not copy a patent URI from a random
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
-          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/32113/status",
+          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
 		  
 
 		  localBiblio: {
 		"UTS18": {
 		    title: "Unicode Technical Standard #18: Unicode Regular Expressions",
-			href: "http://unicode.org/reports/tr18/",
+			href: "https://unicode.org/reports/tr18/",
 			authors: [ "Mark Davis", "Andy Heninger" ]
 		},
 		
 		"Encoding": {
 			title: "Encoding",
-			href: "http://www.w3.org/TR/encoding/",
+			href: "https://www.w3.org/TR/encoding/",
 			authors: [ "Anne van Kesteren", "Joshua Bell", "Addison Phillips" ]
 		},
 		
@@ -83,37 +83,37 @@
 		
 		"UTS10": {
 			title: "Unicode Technical Standard #10: Unicode Collation Algorithm",
-			href: "http://www.unicode.org/reports/tr10/",
+			href: "https://www.unicode.org/reports/tr10/",
 			authors: [ "Mark Davis", "Ken Whistler", "Markus Scherer" ]
 		},
 		
 		"UAX11": {
 		    title: "Unicode Standard Annex #11: East Asian Width",
-		    href: "http://www.unicode.org/reports/tr11/",
+		    href: "https://www.unicode.org/reports/tr11/",
 		    authors: [ "Ken Lunde 小林劍" ]
 		},
 		
 		"UAX29": {
 			title: "Unicode Standard Annex #29: Unicode Text Segmentation",
-			href: "http://www.unicode.org/reports/tr29/",
+			href: "https://www.unicode.org/reports/tr29/",
 			authors: [ "Mark Davis" ]
 		},
 		
 		"UTS39": {
 		    title: "Unicode Technical Standard #39: Unicode Security Mechanisms",
-		    href: "http://www.unicode.org/reports/tr39/",
+		    href: "https://www.unicode.org/reports/tr39/",
 		    authors: [ "Mark Davis", "Michel Suignard" ]
 		},
 		
 		"UTR36": {
 			title: "Unicode Technical Report #36: Unicode Security Considerations",
-			href: "http://www.unicode.org/reports/tr36/",
+			href: "https://www.unicode.org/reports/tr36/",
 			authors: [ "Mark Davis", "Michel Suignard" ]
 		},
 		
 		"UTR50": {
 		    title: "Unicode Technical Report #50: Unicode Vertical Text Layout",
-		    href: "http://www.unicode.org/reports/tr50/",
+		    href: "https://www.unicode.org/reports/tr50/",
 		    authors: [ "Koji Ishii 石井宏治", "Laurențiu Iancu" ]
 		},
 		
@@ -220,7 +220,7 @@
         <p>A <dfn data-lt="transcoder|transcoders">transcoder</dfn> is a process that converts 
 		text between two character encodings. Most commonly in this document it 
 		refers to a process that converts from a <a>legacy character encoding</a> 
-        to a <a href="http://www.w3.org/TR/2005/REC-charmod-20050215/#Unicode_Encoding_Form">Unicode encoding form</a>, 
+        to a <a href="https://www.w3.org/TR/2005/REC-charmod-20050215/#Unicode_Encoding_Form">Unicode encoding form</a>, 
 		such as UTF-8.</p>
         <p><dfn id="def_syntactic_content">Syntactic content</dfn> is any text in a document format or protocol that belongs to the structure of the format or protocol. This definition includes values that are typically thought of as "markup" but can also include other values, such as the name of a field in an HTTP header. Syntactic content consists of all of the characters that form the <em>structure</em> of a format or protocol. For example, <span class="qchar">&lt;</span> and <span class="qchar">&gt;</span> (as well as the element name and various attributes they surround) are part of the syntactic content in an HTML document.</p>
         <p>Syntactic content usually is defined by a specification or specifications and
@@ -291,7 +291,7 @@
           cluster in this document refers to an extended default grapheme
           cluster. (A discussion of grapheme clusters is also given in Section 2
            of the <cite>Unicode Standard</cite>, [[!Unicode]]. Cf. near the end of
-           <a href="http://www.unicode.org/versions/Unicode8.0.0/ch02.pdf">Section 2.11</a>
+           <a href="https://www.unicode.org/versions/Unicode8.0.0/ch02.pdf">Section 2.11</a>
            in version 8.0 of The Unicode Standard)</p>
         <p>Because different natural languages have different needs, grapheme clusters
           can also sometimes require tailoring. For example, a Slovak user might


### PR DESCRIPTION
This commit changes some links to HTTPS, fixing a ReSpec warning (insecure URLs are not allowed in `respecConfig`).