### PR TITLE
Add appropriate banner [I18N-ACTION-149]

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,11 +47,10 @@
       <p>This document describes string searching operations on the Web in order to allow greater interoperability. String searching refers to natural language string matching such as the "find" command in a Web browser. This document builds upon the concepts found in <cite>Character Model for the World Wide Web 1.0: Fundamentals </cite>[[CHARMOD]] and <cite>Character Model for the World Wide Web 1.0: String Matching</cite> [[CHARMOD-NORM]] to provide authors of specifications, software developers, and content developers the information they need to describe and implement search features suitable for global audiences.</p>
     </section>
     <section id="sotd">
-      <div class="note">
-        <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending comments on this document</p>
-        <p data-lang="en">If you wish to make comments regarding this document, please raise them as <a href="https://github.com/w3c/string-search/issues" style="font-size: 120%;">github issues</a> against the latest <a href="https://w3c.github.io/string-search"> editor's copy</a>. Only send comments by email if you are unable to raise issues on github (see links below). All comments are welcome.</p>
-        
-        <p data-lang="en">To make it easier to track comments, please raise separate issues or emails for each comment, and point to the section you are commenting on using a URL.</p>
+      <div class="issue">
+        <p data-lang="en" style="font-weight: bold; font-size: 120%">Caution: work in progress</p>
+        <p data-lang="en">This document is not being actively developed by the Internationalization Working Group. It was created to capture information about substring matching in [=natural language=] text that was off-topic in other I18N documents as well as to serve as a ready reference for conversations about the problems of substring matching on the Web.</p>
+        <p>Readers should not expect that the materials found here represent full guidance for the implementation or specification of "find" features.</p>
       </div>
     </section>
     <section id="intro">


### PR DESCRIPTION
This removes the text about submitting comments on github (which date from the early days of github adoption and are no longers needed) and instead places an "issue" box declaring the status of the work.

i18n-actions#149 